### PR TITLE
Rename and add missing parameter to RequestMarkers_Func

### DIFF
--- a/Include/GWCA/Managers/QuestMgr.h
+++ b/Include/GWCA/Managers/QuestMgr.h
@@ -36,9 +36,9 @@ namespace GW {
         // Find and populate a wchar_t* buffer with the encoded name of the category the quest belongs to in the quest log. Returns false on failure.
         GWCA_API bool GetQuestEntryGroupName(GW::Constants::QuestID quest_id, wchar_t* out, size_t out_len);
 
-        GWCA_API bool RequestQuestInfo(const Quest* quest);
+        GWCA_API bool RequestQuestInfo(const Quest* quest, bool update_markers=false);
         
-        GWCA_API bool RequestQuestInfoId(Constants::QuestID quest_id);
+        GWCA_API bool RequestQuestInfoId(Constants::QuestID quest_id, bool update_markers=false);
 
     };
 }


### PR DESCRIPTION
* Retyped RequestMarkers_Func to expose its second parameter
* Passed second parameter (true to update markers) through to RequestQuestInfo functions, with default value false
* Renamed RequestMarkers_Func to RequestQuestData_Func for a more accurate name