### PR TITLE
Fix crash when moving non-bag item onto empty bag slot

### DIFF
--- a/Source/ItemMgr.cpp
+++ b/Source/ItemMgr.cpp
@@ -146,14 +146,16 @@ namespace {
         GWCA_ASSERT(message_id == UI::UIMessage::kSendMoveItem && wparam);
         MoveItem_UIMessage* packet = (MoveItem_UIMessage*)wparam;
         const auto bag = Items::GetBag(packet->bag_id);
-        GWCA_ASSERT(bag);
+        uint32_t bag_index = bag ? bag->index : (static_cast<uint32_t>(packet->bag_id) - 1);
+
         // Make sure the user is allowed to move the item by the game
+        // edge case: bag can be null if moving an item to an empty bag slot
         if (!status->blocked && !CanAccessXunlaiChest()) {
-            if (IsStorageItem(Items::GetItemById(packet->item_id)) || IsStorageBag(bag))
+            if (IsStorageItem(Items::GetItemById(packet->item_id)) || (bag && IsStorageBag(bag)))
                 status->blocked = true;
         }
         if (!status->blocked) {
-            MoveItem_Ret(packet->item_id, packet->quantity, bag->index, packet->slot);
+            MoveItem_Ret(packet->item_id, packet->quantity, bag_index, packet->slot);
         }
     }
 


### PR DESCRIPTION
`bag` is (correctly) null when there is no bag in the specified slot, and you attempt to move an item to it, so we need to be able to derive the correct bag index without referencing the bag itself.

I'm not sure whether subtracting one from the bag_id is morally correct, but as a workaround it does the job.  Alternatively we could maybe just assume the UI message should be blocked in that case as the move will fail anyway.