### PR TITLE
Fix wrongly implemented prefix increment operator overload for GW::Constants::Bag class

### DIFF
--- a/Include/GWCA/Constants/Constants.h
+++ b/Include/GWCA/Constants/Constants.h
@@ -97,15 +97,13 @@ namespace GW {
             Storage_8, Storage_9, Storage_10, Storage_11, Storage_12,
             Storage_13, Storage_14, Equipped_Items, Max
         };
-        inline Bag operator++(Bag bag) {
-            if (bag == Bag::Max) return Bag::Max;
-            return static_cast<Bag>(static_cast<uint8_t>(bag) + 1);
+        inline Bag& operator++(Bag& bag) {
+            if (bag == Bag::Max) return bag;
+            bag = static_cast<Bag>(static_cast<uint8_t>(bag) + 1);
+            return bag;
         }
         inline Bag operator++(Bag& bag, int) {
-            if (bag == Bag::Max) return Bag::Max;
-            const auto cur = bag;
-            bag = static_cast<Bag>(static_cast<uint8_t>(bag) + 1);
-            return cur;
+            return operator++(bag);
         }
 
         // Order of storage panes.

--- a/Include/GWCA/Constants/Constants.h
+++ b/Include/GWCA/Constants/Constants.h
@@ -103,7 +103,9 @@ namespace GW {
             return bag;
         }
         inline Bag operator++(Bag& bag, int) {
-            return operator++(bag);
+            const Bag cpy = bag;
+            ++bag;
+            return cpy;
         }
 
         // Order of storage panes.


### PR DESCRIPTION
Bag increment is wrongly implemented. The variable is not being incremented at all when used as a prefix increment (postfix was correct). This led to an infinite loop when used in a loop where the variable is expected to increment. The return value was also a copy, not a reference, which is unexpected. A prefix increment is expected to return a reference to the object being incremented, leading to further confusion due to a non-standard implementation.

This change fixes the prefix operator and reuses it when calling the postfix operator, as there is no reason to implement the same method twice.

Here is the old (wrongly) implemented operator demonstrated:

https://ideone.com/kROMPr

And here is the correctly implemented operator demonstrated:

https://ideone.com/wMypay
